### PR TITLE
[HOPSWORKS-771] Allow memory quota configuration in yarn

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -277,6 +277,9 @@ default['hops']['yarn']['quota_monitor_interval']            = 1000
 default['hops']['yarn']['quota_ticks_per_credit']            = 60
 default['hops']['yarn']['quota_min_ticks_charge']            = 600
 default['hops']['yarn']['quota_checkpoint_nbticks']          = 600
+default['hops']['yarn']['quota_threshold_gpu']               = 0.2
+default['hops']['yarn']['quota_minimum_charged_mb']          = 1024
+default['hops']['yarn']['quota_variable_price_enabled']      = "true"
 default['hops']['yarn']['nm_heapsize_mbs']                   = 1000
 default['hops']['yarn']['rm_heapsize_mbs']                   = 1000
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -165,6 +165,18 @@ attribute "hops/yarn/quota_checkpoint_nbticks",
           :description => "",
           :type => "string"
 
+attribute "hops/yarn/quota_threshold_gpu",
+          :description => "",
+          :type => "string"
+
+attribute "hops/yarn/quota_minimum_charged_mb",
+          :description => "",
+          :type => "string"
+
+attribute "hops/yarn/quota_variable_price_enabled",
+          :description => "",
+          :type => "string"
+
 attribute "hops/yarn/nm_heapsize_mbs",
           :description => "Increase this value if using the YARN external shuffle service. (default: 1000)",
           :type => 'string'

--- a/templates/default/yarn-site.xml.erb
+++ b/templates/default/yarn-site.xml.erb
@@ -369,6 +369,20 @@
     <value><%= node['hops']['yarn']['quota_checkpoint_nbticks'] %></value>
   </property>
   <property>
+    <name>yarn.resourcemanager.quota.multiplicator.threshold.gpu</name>
+    <value><%= node['hops']['yarn']['quota_threshold_gpu'] %></value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.quota.minimum.charged.mb</name>
+    <value><%= node['hops']['yarn']['quota_minimum_charged_mb'] %></value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.quota.variable.price.enabled</name>
+    <value><%= node['hops']['yarn']['quota_variable_price_enabled'] %></value>
+  </property>
+
+
+  <property>
     <name>yarn.resourcemanager.proxy-user-privileges.enabled</name>
     <value>true</value>
   </property>


### PR DESCRIPTION
https://github.com/logicalclocks/hops-testing/pull/211

To cherry-pick to 0.6