### PR TITLE
[HOPSWORKS-853] Feature Store Tour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bin/*
 Berksfile.lock
 *~
 *#
+
+.idea

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -371,21 +371,6 @@ default['hops']['capacity']['queue_mapping_override']['enable']         = "false
 default['hops']['flyway']['version']                                    = "5.0.3"
 default['hops']['flyway_url']                                           = node['download_url'] + "/flyway-commandline-#{node['hops']['flyway']['version']}-linux-x64.tar.gz"
 
-#
-# Hops API jar
-#
-default['hops']['hopsutil_version']                    = node['install']['version']
-default['hops']['hopsutil']['url']                     = "#{node['download_url']}/hopsutil/#{node['hops']['hopsutil_version']}/hops-util-#{node['hops']['hopsutil_version']}.jar"
-
-#
-# Hops Examples files
-#
-default['hops']['hopsexamples_version']                = node['install']['version']
-default['hops']['hopsexamples_spark']['url']          = "#{node['download_url']}/hopsexamples/#{node['hops']['hopsexamples_version']}/hops-examples-spark-#{node['hops']['hopsexamples_version']}.jar"
-default['hops']['hopsexamples_hive']['url']           = "#{node['download_url']}/hopsexamples/#{node['hops']['hopsexamples_version']}/hops-examples-hive-#{node['hops']['hopsexamples_version']}.jar"
-default['hops']['hopsexamples_flink']['url']          = "#{node['download_url']}/hopsexamples/#{node['hops']['hopsexamples_version']}/hops-examples-flink-#{node['hops']['hopsexamples_version']}.jar"
-
-
 #GPU
 default['hops']['yarn']['min_gpus']                    = 0
 default['hops']['yarn']['max_gpus']                    = 10

--- a/metadata.rb
+++ b/metadata.rb
@@ -473,14 +473,6 @@ attribute "hops/yarn/linux_container_limit_users",
           :description => "",
           :type => "string"
 
-attribute "hops/hopsutil_version",
-          :description => "Version of the hops-util jar file.",
-          :type => "string"
-
-attribute "hops/hopsexamples_version",
-          :description => "Version of the hops-spark jar file.",
-          :type => "string"
-
 attribute "hops/yarn/cgroups",
           :description => "'true' to enable cgroups (default), else 'false'",
           :type => "string"


### PR DESCRIPTION
- Move spark-example and hops-util spark dependency attributes from hops-hadoop-chef to spark-chef