### PR TITLE
[HOPSWORKS-923] Availability Zone Awareness support for HopsFS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -398,3 +398,16 @@ default['hops']['kernel']['somaxconn']                  = 4096
 default['hops']['kernel']['swappiness']                 = 1
 default['hops']['kernel']['overcommit_memory']          = 1
 default['hops']['kernel']['overcommit_ratio']           = 100
+
+
+#LocationDomainId
+default['hops']['nn']['private_ips_domainIds']        = {}
+default['hops']['dn']['private_ips_domainIds']        = {}
+default['hops']['topology']                           = "false"
+
+# graphite metrics
+default['hops']['metrics']['use_graphite']            = "true"
+default['hops']['nn']['enable_retrycache']            = "true"
+
+default['hops']['hdfs']['quota_enabled']              = "true"
+default['hops']['nn']['handler_count']                = 120

--- a/metadata.rb
+++ b/metadata.rb
@@ -497,6 +497,34 @@ attribute "hopsworks/default/private_ips",
           :description => "Hopsworks private ip",
           :type => "string"
 
+attribute "hops/nn/private_ips_domainIds",
+          :description => "private_ips to LocationDomainIds for namenodes",
+          :type => "hash"
+
+attribute "hops/dn/private_ips_domainIds",
+          :description => "private_ips to LocationDomainIds for datanodes",
+          :type => "hash"
+
+attribute "hops/topology",
+          :description => "'true' or 'false' - true to enable the network topology. Default is false.",
+          :type => "string"
+
+attribute "hops/metrics/use_graphite",
+          :description => "'true' or 'false' - true to use graphite as a sink for metrics. Default is true.",
+          :type => "string"
+
+attribute "hops/nn/enable_retrycache",
+          :description => "'true' or 'false' - true to enable retryCache. Default is true.",
+          :type => "string"
+
+attribute "hops/hdfs/quota_enabled",
+          :description => "'true' or 'false' - true to enable hdfs quota. Default is true.",
+          :type => "string"
+
+attribute "hops/nn/handler_count",
+          :description => "Number of RPC handlers",
+          :type => "string" 
+
 # Kernel tuning parameters
 attribute "hops/kernel/somaxconn",
           :description => "net.core.somaxconn value",

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -350,3 +350,21 @@ if my_ip.eql? node['hops']['nn']['private_ips'][0]
     only_if do File.exist?("#{node['hops']['bin_dir']}/hadoop_logs_mgm.py") end
   end
 end
+
+if node['hops']['topology'].eql? "true"
+  template "#{node['hops']['conf_dir']}/get-topology.sh" do
+    source "get-topology.sh.erb"
+    owner node['hops']['hdfs']['user']
+    group node['hops']['group']
+    mode "755"
+    action :create
+  end
+
+  template "#{node['hops']['conf_dir']}/topology" do
+    source "topology.erb"
+    owner node['hops']['hdfs']['user']
+    group node['hops']['group']
+    mode "755"
+    action :create
+  end
+end

--- a/recipes/nn.rb
+++ b/recipes/nn.rb
@@ -73,7 +73,7 @@ if node['hops']['nn']['partition_key'].eql? "false"
 end
 
 nnHTTPAddress = "#{my_ip}:#{node['hops']['nn']['http_port']}"
-
+locDomainId = node['hops']['nn']['private_ips_domainIds'].has_key?(my_ip) ? node['hops']['nn']['private_ips_domainIds'][my_ip] : 0
 template "#{node['hops']['conf_dir']}/hdfs-site.xml" do
   source "hdfs-site.xml.erb"
   owner node['hops']['hdfs']['user']
@@ -84,7 +84,8 @@ template "#{node['hops']['conf_dir']}/hdfs-site.xml" do
               :firstNN => myNN,
               :cache => cache,
               :partition_key => partition_key,
-              :nnHTTPAddress => nnHTTPAddress
+              :nnHTTPAddress => nnHTTPAddress,
+              :locationDomainId => locDomainId
             })
   action :create
 end
@@ -232,7 +233,7 @@ if my_ip.eql? node['hops']['nn']['private_ips'][0]
       group node['hops']['group']
       mode "1750"
     end
-    
+
   exec = "#{node['ndb']['scripts_dir']}/mysql-client.sh"
   bash 'insert_hopsworks_as_hdfs_superuser' do
     user "root"

--- a/templates/default/core-site.xml.erb
+++ b/templates/default/core-site.xml.erb
@@ -274,5 +274,10 @@
   </property>
 
   <% end -%>
- 
+<% if node['hops']['topology'].eql? "true" -%>
+ <property>
+   <name>net.topology.script.file.name</name>
+   <value><%=node['hops']['conf_dir']%>/get-topology.sh</value>
+ </property>
+<% end -%>
 </configuration>

--- a/templates/default/get-topology.sh.erb
+++ b/templates/default/get-topology.sh.erb
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+if [ $# -gt 0 ]; then
+
+TOPOLOGY_FILE=${TOPOLOGY_FILE:-"topology"}
+
+HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-"<%= node['hops']['conf_dir'] %>"}
+
+if [ ! -f ${HADOOP_CONF_DIR}/${TOPOLOGY_FILE} ]; then
+ echo "/default/default-rack "
+ exit 0
+fi
+
+while [ $# -gt 0 ] ; do
+ nodeArg=$1
+ exec< ${HADOOP_CONF_DIR}/${TOPOLOGY_FILE}
+ result=""
+ while read line ; do
+ ar=( $line )
+ if [ "${ar[0]}" = "$nodeArg" ] ; then
+ result="${ar[1]}"
+ fi
+ done
+ shift
+ echo "$result"
+done
+
+else
+ echo "/default/default-rack "
+fi

--- a/templates/default/hadoop-metrics2.properties.erb
+++ b/templates/default/hadoop-metrics2.properties.erb
@@ -18,6 +18,7 @@
 # syntax: [prefix].[source|sink].[instance].[options]
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
+<% if node['hops']['metrics']['use_graphite'] == "true" %>
 # Send the metrics to graphite endpoint
 *.sink.graphite.class=org.apache.hadoop.metrics2.sink.GraphiteSink
 # default sampling period, in seconds
@@ -38,3 +39,5 @@ datanode.sink.graphite.metrics_prefix=datanode
 namenode.sink.graphite.server_host=<%= @influxdb_ip %>
 namenode.sink.graphite.server_port=<%= node['influxdb']['graphite']['port'] %>
 namenode.sink.graphite.metrics_prefix=namenode
+
+<% end %>

--- a/templates/default/hdfs-site.xml.erb
+++ b/templates/default/hdfs-site.xml.erb
@@ -58,7 +58,7 @@
 
   <property>
     <name>dfs.namenode.handler.count</name>
-    <value>120</value>
+    <value><%= node['hops']['nn']['handler_count'] %></value>
     <description>The RPC server that listens to requests from clients</description>
   </property>
 
@@ -209,7 +209,7 @@
 
   <property>
     <name>dfs.namenode.quota.enabled</name>
-    <value>true</value>
+    <value><%= node['hops']['hdfs']['quota_enabled'] %></value>
     <description></description>
   </property>
 
@@ -381,6 +381,16 @@
 <property>
    <name>dfs.block.access.token.enable</name>
    <value><%= node['hops']['encrypt_data_transfer']['enabled'] %></value>
+</property>
+
+<property>
+   <name>dfs.namenode.enable.retrycache</name>
+   <value><%= node['hops']['nn']['enable_retrycache'] %></value>
+</property>
+
+<property>
+   <name>dfs.locationDomainId</name>
+   <value><%= @locationDomainId %></value>
 </property>
 
 </configuration>

--- a/templates/default/topology.erb
+++ b/templates/default/topology.erb
@@ -1,0 +1,5 @@
+<% if (node.attribute?(:hops) && node['hops'].attribute?(:dn) && node['hops']['dn'].attribute?(:private_ips_domainIds) && !node['hops']['dn']['private_ips_domainIds'].empty?) -%>
+<% for dn, locdomainId in node['hops']['dn']['private_ips_domainIds'] -%>
+<%= dn%> /d<%=locdomainId%>/r1
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Added LocationDomainId for nn and network topology based on the GCE availability zones (locationDomainIds)
Add attributes for handler count, hdfs quota, retry cache, and graphite

Tests: https://github.com/logicalclocks/hops-testing/pull/285

**Notes** 
* This pull request is dependent on the new changes in Karamel to assign a locationDomainId to each ip, however, it is backward compatible, if no locationDomainId is provided, it will use the default value 0.
* Availability Zone Awareness support is added to HopsFS v2.8.2.8
