### PR TITLE
[HOPSWORKS-966]  Give 777 permission to MapReduce History Server dir

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -129,8 +129,9 @@ default['hops']['rm']['scheduler_capacity']['calculator_class']  = "org.apache.h
 default['hops']['mr']['tmp_dir']               = "/mapreduce"
 default['hops']['mr']['staging_dir']           = "#{default['hops']['mr']['tmp_dir']}/#{default['hops']['mr']['user']}/staging"
 
-default['hops']['jhs']['inter_dir']            = "/mr-history/done_intermediate"
-default['hops']['jhs']['done_dir']             = "/mr-history/done"
+default['hops']['jhs']['root_dir']             = "/mr-history"
+default['hops']['jhs']['inter_dir']            = "#{node['hops']['jhs']['root_dir']}/done_intermediate"
+default['hops']['jhs']['done_dir']             = "#{node['hops']['jhs']['root_dir']}/done"
 
 # YARN CONFIG VARIABLES
 # http://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-common/yarn-default.xml

--- a/metadata.rb
+++ b/metadata.rb
@@ -201,6 +201,10 @@ attribute "hops/rm/public_ips",
           :description => "Set ip addresses",
           :type => "array"
 
+attribute "hops/jhs/root_dir",
+          :description => "Root directory in HDFS for MapReduce History Server",
+          :type => "string"
+
 # Needed to find the jar file for yan-spark-shuffle
 attribute "hadoop_spark/version",
           :description => "Spark version",

--- a/recipes/jhs.rb
+++ b/recipes/jhs.rb
@@ -13,18 +13,26 @@ for script in node['hops']['yarn']['scripts']
   end
 end 
 
+hops_hdfs_directory "#{node['hops']['jhs']['root_dir']}" do
+  action :create_as_superuser
+  owner node['hops']['mr']['user']
+  group node['hops']['group']
+  mode "1775"
+end
 
-tmp_dirs   = ["/mr-history", node['hops']['jhs']['inter_dir'], node['hops']['jhs']['done_dir']]
+hops_hdfs_directory "#{node['hops']['jhs']['inter_dir']}" do
+  action :create_as_superuser
+  owner node['hops']['mr']['user']
+  group node['hops']['group']
+  mode "1777"
+end
 
- for d in tmp_dirs
-   Chef::Log.info "Creating hdfs directory: #{d}"
-   hops_hdfs_directory d do
-    action :create_as_superuser
-    owner node['hops']['mr']['user']
-    group node['hops']['group']
-    mode "1775"
-   end
- end
+hops_hdfs_directory "#{node['hops']['jhs']['done_dir']}" do
+  action :create_as_superuser
+  owner node['hops']['mr']['user']
+  group node['hops']['group']
+  mode "1777"
+end
 
 node.normal['mr']['dirs'] = [node['hops']['mr']['staging_dir'], node['hops']['mr']['tmp_dir'], node['hops']['hdfs']['user_home'] + "/" + node['hops']['mr']['user']]
  for d in node['mr']['dirs']


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-966

This is required when running Apache Sqoop as a project specific user. History server does not store any sensitive information and it is available anyway through a REST API