### PR TITLE
[HOPSWORKS-1162] Make Hadoop home readable for everybody

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -163,7 +163,7 @@ template "#{node['hops']['conf_dir']}/log4j.properties" do
   source "log4j.properties.erb"
   owner node['hops']['hdfs']['user']
   group node['hops']['group']
-  mode "640"
+  mode "644"
   action :create
 end
 
@@ -175,7 +175,7 @@ template "#{node['hops']['conf_dir']}/core-site.xml" do
   source "core-site.xml.erb"
   owner node['hops']['hdfs']['user']
   group node['hops']['group']
-  mode "740"
+  mode "744"
   variables({
      :defaultFS => defaultFS,
      :hopsworks => hopsworksNodes,
@@ -246,7 +246,7 @@ template "#{node['hops']['conf_dir']}/hdfs-site.xml" do
   source "hdfs-site.xml.erb"
   owner node['hops']['hdfs']['user']
   group node['hops']['group']
-  mode "750"
+  mode "754"
   cookbook "hops"
   variables({
     :nn_rpc_address => nn_rpc_address,
@@ -261,7 +261,7 @@ template "#{node['hops']['conf_dir']}/erasure-coding-site.xml" do
   source "erasure-coding-site.xml.erb"
   owner node['hops']['hdfs']['user']
   group node['hops']['group']
-  mode "740"
+  mode "744"
   action :create
 end
 
@@ -285,7 +285,7 @@ template "#{node['hops']['conf_dir']}/yarn-site.xml" do
   owner node['hops']['yarn']['user']
   group node['hops']['group']
   cookbook "hops"
-  mode "740"
+  mode "744"
   variables( lazy {
     h = {}
     h[:rm_private_ip] = rm_private_ip
@@ -315,7 +315,7 @@ template "#{node['hops']['conf_dir']}/hadoop-metrics2.properties" do
   source "hadoop-metrics2.properties.erb"
   owner node['hops']['hdfs']['user']
   group node['hops']['group']
-  mode "750"
+  mode "754"
   variables({
     :influxdb_ip => influxdb_ip
   })

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -287,7 +287,7 @@ bash 'extract-hadoop' do
 
         # chown -L : traverse symbolic links
         chown -RL #{node['hops']['hdfs']['user']}:#{node['hops']['group']} #{node['hops']['base_dir']}
-        chmod 750 #{node['hops']['home']}
+        chmod 755 #{node['hops']['home']}
 
         # Write flag
         touch #{hin}
@@ -315,7 +315,7 @@ for dir in lce_dirs do
   directory dir do
     owner "root"
     group node['hops']['group']
-    mode "0750"
+    mode "0755"
   end
 end
 
@@ -402,7 +402,7 @@ template "#{node['hops']['conf_dir']}/mapred-site.xml" do
   source "mapred-site.xml.erb"
   owner node['hops']['mr']['user']
   group node['hops']['group']
-  mode "750"
+  mode "754"
   variables({
       :rm_private_ip => rm_private_ip,
       :jhs_private_ip => jhs_private_ip


### PR DESCRIPTION
Some applications need to be able to access Hadoop binaries and
configurations without being in the hadoop group. Grant read
access to everybody to non-sensitive files.