### PR TITLE
[HOPSWORKS-1588] Increased default Java heap size and DirectByteBuffer size to 1G (#181)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -241,8 +241,8 @@ default['hops']['rm']['https']['port'] 	    = "8090"
 default['hops']['nm']['https']['port']      = "45443"
 
 default['hops']['yarn']['resource_tracker'] = "false"
-default['hops']['nn']['direct_memory_size'] = 50
-default['hops']['nn']['heap_size']          = 500
+default['hops']['nn']['direct_memory_size'] = 1000
+default['hops']['nn']['heap_size']          = 1000
 
 default['hops']['nn']['public_ips']         = ['10.0.2.15']
 default['hops']['nn']['private_ips']        = ['10.0.2.15']

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,6 +1,10 @@
 include_recipe "hops::_config"
 include_recipe "java"
 
+if node['hops']['nn']['direct_memory_size'].to_i < node['hops']['nn']['heap_size'].to_i
+  raise "Invalid Configuration. Set Java DirectByteBuffer memory as high as Java heap size otherwise, the NNs might experience severe GC pauses."
+end
+
 group node['kagent']['certs_group'] do
   action :create
   not_if "getent group #{node['kagent']['certs_group']}"


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1588

Co-authored-by: Salman Niazi <salman@logicalclocks.com>