### PR TITLE
[HOPSWORKS-1666] Enable NM detect hw capabilities by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -99,7 +99,7 @@ default['hops']['yarn']['vmem_check']          = false
 end
 default['hops']['yarn']['pmem_check']          = "true"
 
-default['hops']['yarn']['detect-hardware-capabilities'] = "false"
+default['hops']['yarn']['detect-hardware-capabilities'] = "true"
 default['hops']['yarn']['logical-processors-as-cores']  = "true"
 default['hops']['yarn']['pcores-vcores-multiplier']     = "0.9"
 default['hops']['yarn']['system-reserved-memory-mb']    = "-1"


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1666