### PR TITLE
[HOPSWORKS-1864] Revert HopsFS data dir location to be compatible wit…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,10 +47,8 @@ default['hops']['cloud_store_small_files_in_db']   = "true"
 default['hops']['nn']['root_dir_storage_policy']       = ""
 
 
-default['hops']['dn']['data_dir']                       = "file://" + node['hops']['data_dir'] + "/hdfs/dn/disk"
-default['hops']['dn']['cloud_data_dir']                 = "file://" + node['hops']['data_dir'] + "/hdfs/dn/cloud"
+default['hops']['dn']['data_dir']                       = "file://" + node['hops']['data_dir'] + "/hdfs/dn"
 default['hops']['dn']['data_dir_permissions']           = '700'
-default['hops']['dn']['cloud_data_dir_permissions']     = '700'
 default['hops']['nn']['name_dir']                       = "file://" + node['hops']['data_dir'] + "/hdfs/nn"
 
 default['hops']['yarn']['nodemanager_recovery_dir']          = node['hops']['data_dir'] + "/yarn-nm-recovery"

--- a/metadata.rb
+++ b/metadata.rb
@@ -509,15 +509,6 @@ attribute "hops/aws_s3_bucket",
           :description => "S3 bucket used to store file system blocks",
           :type => 'string'
 
-attribute "hops/dn/cloud_data_dir",
-          :description => "The directory in which Hadoop's DataNodes put cached data from cloud storage, such as, S3.",
-          :type => 'string'
-
-attribute "hops/dn/cloud_data_dir_permissions",
-          :description => "The permissions for the directory in which Hadoop's DataNodes put cached data from cloud storage (default: 700)",
-          :type => 'string'
-
-
 attribute "hops/yarn/nodemanager_hb_ms",
           :description => "Heartbeat Interval for NodeManager->ResourceManager in ms",
           :type => 'string'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -260,19 +260,6 @@ else
   end
 end
 
-if node['hops']['enable_cloud_storage'].casecmp?("true")
-  cdd=node['hops']['dn']['cloud_data_dir']
-  cloudDataDir=cdd.gsub("file://","")
-
-  directory cloudDataDir do
-    owner node['hops']['hdfs']['user']
-    group node['hops']['group']
-    mode "0770"
-    recursive true
-    action :create
-  end
-end 
-
 ann=node['hops']['nn']['name_dir']
 nndir=ann.gsub("file://","")
 directory nndir do

--- a/recipes/purge.rb
+++ b/recipes/purge.rb
@@ -53,12 +53,6 @@ directory node['hops']['data_dir'] do
   ignore_failure true
 end
 
-directory node['hops']['dn']['cloud_data_dir'] do
-  recursive true
-  action :delete
-  ignore_failure true
-end
-
 directory Chef::Config.file_cache_path do
   recursive true
   action :delete


### PR DESCRIPTION


I have removed cloud_data_dir and cloud_data_dir_permissions parameters as they were not used

and I have reverted the data_dir path to .../hdfs/dn . For cloud I changed it to ../hdfs/dn/disk but, it breaks the upgrade. 