### PR TITLE
[HOPS-1588] truncate leader election tables on upgrade

### DIFF
--- a/recipes/nn.rb
+++ b/recipes/nn.rb
@@ -19,6 +19,17 @@ kagent_hopsify "Generate x.509" do
   not_if { conda_helpers.is_upgrade || node["kagent"]["enabled"] == "false" }
 end
 
+exec = "#{node['ndb']['scripts_dir']}/mysql-client.sh"
+bash 'truncate_le_tables' do
+  user "root"
+  code <<-EOF
+      set -e
+      #{exec} -e \"TRUNCATE #{node['hops']['db']}.hdfs_le_descriptors\"
+      #{exec} -e \"TRUNCATE #{node['hops']['db']}.yarn_le_descriptors\"
+    EOF
+  only_if { conda_helpers.is_upgrade }
+end
+
 file "#{node['hops']['conf_dir']}/dfs.exclude" do 
   owner node['hops']['hdfs']['user']
   group node['hops']['group']


### PR DESCRIPTION
https://hopshadoop.atlassian.net/jira/software/c/projects/HOPS/issues/HOPS-1588/?filter=allissues

The leader namenode recreate these missing rows when a cluster restart is detected. Currently we detect cluster restart using the leader election tables. If the tables are empty then it means all the namenode(s) were shut down and it is safe for the leader to recreate these missing rows. During upgrades we have some rows left in the leader election tables by the previous version of Hops. Simply truncating the leader election tables will fix this problem. 