### PR TITLE
[HOPSWORKS-2287] Bump up docker.io version for ubuntu

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -465,7 +465,7 @@ default['hops']['gpu']                                = "false"
 
 #DOCKER
 default['hops']['docker']['enabled']                  = "true"
-default['hops']['docker_version']['ubuntu']           = "19.03.6-0ubuntu1~18.04.2"
+default['hops']['docker_version']['ubuntu']           = "19.03.6-0ubuntu1~18.04.*"
 default['hops']['docker_version']['centos']           = "19.03.8-3"
 default['hops']['selinux_version']['centos']          = "2.119.1-1.c57a6f9"
 default['hops']['containerd_version']['centos']       = "1.2.13-3.1"


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-2287