### PR TITLE
[HOPSWORKS-2692] Disable Yarn application retry

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -144,7 +144,7 @@ default['hops']['yarn']['nodemanager_hb_ms']   = "1000"
 
 default['hops']['yarn']['max_connect_wait']   = "900000"
 
-default['hops']['am']['max_attempts']           = 2
+default['hops']['am']['max_attempts']          = 1
 
 default['hops']['yarn']['aux_services']        = "spark_shuffle,mapreduce_shuffle"
 


### PR DESCRIPTION
Retrying failing applications has little value in the feature store context.
It confuses the users on the real cause of the error and potentially insert duplicated data.