### PR TITLE
[HOPSWORKS-3086] Disable small files by default as most cluster do no…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -436,7 +436,7 @@ default['hops']['flyway_url']                                           = node['
 default['hops']['yarnapp']['home_dir']                 = "/home"
 
 #Store Small files in NDB
-default['hops']['small_files']['store_in_db']                                       = "true"
+default['hops']['small_files']['store_in_db']                                       = "false"
 default['hops']['small_files']['max_size']                                          = 65536
 
 default['hopsmonitor']['default']['private_ips']                                    = ['10.0.2.15']


### PR DESCRIPTION
…t have NVMe drives for NDB disk data