### PR TITLE
[HOPSWORKS-3169] Configure min user limit in Yarn capacity scheduler

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -427,6 +427,7 @@ default['hops']['capacity']['default_acl_submit_applications']          = "*"
 default['hops']['capacity']['default_acl_administer_queue']             = "*"
 default['hops']['capacity']['queue_mapping']                            = ""
 default['hops']['capacity']['queue_mapping_override']['enable']         = "false"
+default['hops']['capacity']['minimum-user-limit-percent']               = ""
 
 #
 # Flyway - Database upgrades

--- a/metadata.rb
+++ b/metadata.rb
@@ -670,6 +670,10 @@ attribute "hops/capacity/queue_mapping_override.enable",
           :description => "If a queue mapping is present, will it override the value specified by the user? This can be used by administrators to place jobs in queues that are different than the one specified by the user. The default is false.",
           :type => "string"
 
+attribute "hops/capacity/minimum-user-limit-percent",
+          :description => "Each queue enforces a limit on the percentage of resources allocated to a user at any given time, if there is demand for resources. Attribute format: root.default:VALUE-INTEGER,root.queue2:VALUE-INTEGER",
+          :type => "string"
+
 attribute "kagent/enabled",
           :description => "Set to 'true' to enable, 'false' to disable kagent",
           :type => "string"

--- a/templates/default/yarn-site.xml.erb
+++ b/templates/default/yarn-site.xml.erb
@@ -353,6 +353,15 @@
     <value><%= node['hops']['yarn']['min_allocation_memory_mb'] %></value>
   </property>
 
+<% if not node['hops']['capacity']['minimum-user-limit-percent'].empty? -%>
+<% for per_queue in node['hops']['capacity']['minimum-user-limit-percent'].split(',') -%>
+<% pq_split = per_queue.strip().split(':') -%>
+  <property>
+    <name>yarn.scheduler.capacity.<%= pq_split[0] %>.minimum-user-limit-percent</name>
+    <value><%= pq_split[1] %></value>
+  </property>
+<% end -%>
+<% end -%>
 
   <property>
     <name>yarn.nodemanager.resource.cpu-vcores</name>


### PR DESCRIPTION
Expose Capacity scheduler attribute to configure user limit per queue

Resolves https://hopsworks.atlassian.net/browse/HOPSWORKS-3169