### PR TITLE
[HOPSWORKS-3307] hops-hadoop-chef: remove unused params for small files

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -438,8 +438,7 @@ default['hops']['flyway_url']                                           = node['
 
 default['hops']['yarnapp']['home_dir']                 = "/home"
 
-#Store Small files in NDB
-default['hops']['small_files']['store_in_db']                                       = "false"
+#Max small file size
 default['hops']['small_files']['max_size']                                          = 65536
 
 default['hopsmonitor']['default']['private_ips']                                    = ['10.0.2.15']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,7 @@ include_attribute "kzookeeper"
 
 default['hops']['versions']                    = "2.8.2.2,2.8.2.3,2.8.2.4,2.8.2.5,2.8.2.6,2.8.2.7,2.8.2.8,2.8.2.9,2.8.2.10,3.2.0.0,3.2.0.1,3.2.0.2,3.2.0.3,3.2.0.4,3.2.0.5,3.2.0.6"
 default['hops']['version']                     = "3.2.0.7-RC0"
-default['hops']['fuse']['version']             = "1.3.2"
+default['hops']['fuse']['version']             = "1.3.3"
 
 default['hops']['hdfs']['user']                = node['install']['user'].empty? ? "hdfs" : node['install']['user']
 default['hops']['hdfs']['user_id']             = '1506'

--- a/metadata.rb
+++ b/metadata.rb
@@ -767,7 +767,6 @@ attribute "hops/nn/root_dir_storage_policy",
           :description => "Storage policy for root directory",
           :type => "string"
 
-
 attribute "hops/nn/replace-dn-on-failure",
           :description => "When the cluster size is extremely small, e.g. 3 nodes or less, cluster administrators may want to set the 'hops/nn/root_dir_storage_policy' policy to NEVER in the default configuration file or disable this feature. Otherwise, users may experience an unusually high rate of pipeline failures since it is impossible to find new datanodes for replacement.",
           :type => "string"

--- a/templates/default/hdfs-site.xml.erb
+++ b/templates/default/hdfs-site.xml.erb
@@ -441,13 +441,6 @@
 </property>
 <% end %>
 
-<!-- Store Small Files in NDB-->
-
-<property>
-   <name>dfs.store.small.files.in.db</name>
-   <value><%= node['hops']['small_files']['store_in_db'] %></value>
-</property>
-
 <property>
    <name>dfs.db.file.max.size</name>
    <value><%= node['hops']['small_files']['max_size'] %></value>


### PR DESCRIPTION
we can no longer enable / disable small files using this property dfs.store.small.files.in.db. Small files are now controlled by a storage policy. If you set the storage policy to DB for a folder then the new files created in this folder will be stored in the database