### PR TITLE
[HOPSWORKS-3339] Set and export disk utilization size retention for DN Cloud cache (#393)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,6 +59,7 @@ default['hops']['cloud_provider']              = node["install"]["cloud"]
 default['hops']['aws_s3_region']               = "eu-west-1"
 default['hops']['aws_s3_bucket']               = "hopsfs.bucket"
 default['hops']['cloud_bypass_disk_cache']         = "false"
+default['hops']['cloud_cache_delete_activation_percentage'] = "70"
 default['hops']['cloud_max_upload_threads']        = "20"
 default['hops']['cloud_store_small_files_in_db']   = "true"
 default['hops']['disable_non_cloud_storage_policies']       = "false"

--- a/metadata.rb
+++ b/metadata.rb
@@ -585,6 +585,10 @@ attribute "hops/cloud_bypass_disk_cache",
           :description => "Bypass disk cache",
           :type => 'string'
 
+attribute "hops/cloud_cache_delete_activation_percentage",
+          :description => "Disk utilization percentage to start cleaning blocks from DN Cloud cache",
+          :type => 'string'
+
 attribute "hops/cloud_max_upload_threads",
           :description => "Max number of threads for uploading blocks to cloud",
           :type => 'string'

--- a/templates/default/hdfs-site.xml.erb
+++ b/templates/default/hdfs-site.xml.erb
@@ -539,6 +539,12 @@
 </property>
 
 <property>
+   <name>dfs.dn.cloud.cache.delete.activation.percentage</name>
+   <value><%= node['hops']['cloud_cache_delete_activation_percentage'] %></value>
+   <description>Disk utilization percentage to start cleaning blocks from DN Cloud cache</description>
+</property>
+
+<property>
    <name>dfs.dn.cloud.max.upload.threads</name>
    <value><%= node['hops']['cloud_max_upload_threads'] %></value>
    <description></description>


### PR DESCRIPTION
Resolves https://hopsworks.atlassian.net/browse/HOPSWORKS-3339