### PR TITLE
[HOPSFS-124] Watchdog configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -123,6 +123,14 @@ default['hops']['clusterj']['enable_dto_cache']           = "false"
 default['hops']['clusterj']['enable_session_cache']       = "false" 
 default['hops']['clusterj']['max_cached_instances']       = 0 
 
+default['hops']['alive-watchdog']['enabled']          = "false"
+default['hops']['alive-watchdog']['interval']         = "5s"
+default['hops']['alive-watchdog']['poller-class']     = ""
+default['hops']['alive-watchdog']['http-poll']['url'] = ""
+default['hops']['alive-watchdog']['http-poll']['truststore'] = ""
+default['hops']['alive-watchdog']['http-poll']['truststore-password'] = ""
+default['hops']['alive-watchdog']['json-poll']['dc-id'] = ""
+
 default['hops']['nn']['replace-dn-on-failure']        = "true"
 default['hops']['nn']['replace-dn-on-failure-policy'] = "NEVER" 
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -245,6 +245,34 @@ attribute "hops/clusterj/max_cached_instances",
           :description => "Max DTO objects to cache on Clusterj side",
           :type => 'string'
 
+attribute "hops/alive-watchdog/enabled",
+          :description => "Enable alive watchdog service, it requires an external service to poll. Default: false",
+          :type => 'string'
+
+attribute "hops/alive-watchdog/interval",
+          :description => "Poll interval of watchdog. Default: 5s",
+          :type => 'string'
+
+attribute "hops/alive-watchdog/poller-class",
+          :description => "Fully qualified name of the poller class. If empty, and watchdog enabled, the service will not start. Default: empty",
+          :type => 'string'
+
+attribute "hops/alive-watchdog/http-poll/url",
+          :description => "HTTP endpoint to poll for verdict if we should be alive or not. Required if using HTTP based poller class",
+          :type => 'string'
+
+attribute "hops/alive-watchdog/http-poll/truststore",
+          :description => "Optionally specify truststore to use in HTTP poller",
+          :type => 'string'
+
+attribute "hops/alive-watchdog/http-poll/truststore-password",
+          :description => "Password of the truststore to use in HTTP poller",
+          :type => 'string'
+
+attribute "hops/alive-watchdog/json-poll/dc-id",
+          :description => "Configuration of current/your own data-center used by JsonPoller",
+          :type => 'string'
+
 attribute "hops/tls/enabled",
           :description => "'true' will enable RPC TLS and 'false' will disable it",
           :type => 'string'

--- a/templates/default/core-site.xml.erb
+++ b/templates/default/core-site.xml.erb
@@ -379,4 +379,46 @@
   </property>
 <% end -%>
 
+  <property>
+    <name>hops.alive-watchdog.enabled</name>
+    <value><%= node['hops']['alive-watchdog']['enabled'] %></value>
+  </property>
+
+<% if node['hops']['alive-watchdog']['enabled'].casecmp?("true") -%>
+  <property>
+    <name>hops.alive-watchdog.interval</name>
+    <value><%= node['hops']['alive-watchdog']['interval'] %></value>
+  </property>
+
+  <property>
+    <name>hops.alive-watchdog.poller-class</name>
+    <value><%= node['hops']['alive-watchdog']['poller-class'] %></value>
+  </property>
+
+  <property>
+    <name>hops.alive-watchdog.http-poll.url</name>
+    <value><%= node['hops']['alive-watchdog']['http-poll']['url'] %></value>
+  </property>
+
+<% if !node['hops']['alive-watchdog']['http-poll']['truststore'].empty? -%>
+  <property>
+    <name>hops.alive-watchdog.http-poll.truststore</name>
+    <value><%= node['hops']['alive-watchdog']['http-poll']['truststore'] %></value>
+  </property>
+<% end -%>
+
+<% if !node['hops']['alive-watchdog']['http-poll']['truststore-password'].empty? -%>
+  <property>
+    <name>hops.alive-watchdog.http-poll.truststore-password</name>
+    <value><%= node['hops']['alive-watchdog']['http-poll']['truststore-password'] %></value>
+  </property>
+<% end -%>
+
+<% if node['hops']['alive-watchdog']['poller-class'].include?("JsonPoller") -%>
+  <property>
+    <name>hops.alive-watchdog.io.hops.leader_election.watchdog.JsonPoller.dc-id</name>
+    <value><%= node['hops']['alive-watchdog']['json-poll']['dc-id'] %></value>
+  </property>
+<% end -%>
+<% end -%>
 </configuration>

--- a/templates/default/namenode.service.erb
+++ b/templates/default/namenode.service.erb
@@ -5,7 +5,13 @@ After = syslog.target network.target remote-fs.target <%= @deps %>
 #restartSec is 2 so the service restart every 34s
 #a maximum burst of 18 in 11min guaranty that it will at least try for 10min (18*34=612s=10,2min)
 StartLimitIntervalSec=660
+<% if node['hops']['alive-watchdog']['enabled'].casecmp?("true") -%>
+# Do not be very strict as it is normal for the service to fail and restart immediatelly
+# when liveness watchdog is enabled
+StartLimitBurst=350
+<% else -%>
 StartLimitBurst=18
+<% end -%>
 
 [Service]
 User = <%= node['hops']['hdfs']['user'] %>

--- a/templates/default/resourcemanager.service.erb
+++ b/templates/default/resourcemanager.service.erb
@@ -5,7 +5,13 @@ After = syslog.target network.target remote-fs.target <%= @deps %>
 #restartSec is 2 so the service restart every 35s
 #a maximum burst of 18 in 11min guaranty that it will at least try for 10min (18*35=630s=10,5min)
 StartLimitIntervalSec=660
+<% if node['hops']['alive-watchdog']['enabled'].casecmp?("true") -%>
+# Do not be very strict as it is normal for the service to fail and restart immediatelly
+# when liveness watchdog is enabled
+StartLimitBurst=350
+<% else -%>
 StartLimitBurst=18
+<% end -%>
 
 [Service]
 User = <%= node['hops']['rm']['user'] %>


### PR DESCRIPTION
[HOPSFS-124] Do not template empty truststore configuration

[HOPSFS-124] Relax - almost disable - restart limits when liveness watchdog is enabled because it is normal for a service to start and die immediately

[HOPSFS-124]: https://hopsworks.atlassian.net/browse/HOPSFS-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HOPSFS-124]: https://hopsworks.atlassian.net/browse/HOPSFS-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ