### PR TITLE
HOPSFS-139 Bump Hops Hadoop Version to 3.2.0.12

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ include_attribute "ndb"
 include_attribute "kzookeeper"
 
 default['hops']['versions']                    = "2.8.2.2,2.8.2.3,2.8.2.4,2.8.2.5,2.8.2.6,2.8.2.7,2.8.2.8,2.8.2.9,2.8.2.10,3.2.0.0,3.2.0.1,3.2.0.2,3.2.0.3,3.2.0.4,3.2.0.5,3.2.0.6,3.2.0.7,3.2.0.8,3.2.0.9,3.2.0.10,3.2.0.11"
-default['hops']['version']                     = "3.2.0.12-SNAPSHOT"
+default['hops']['version']                     = "3.2.0.12-RC0"
 default['hops']['fuse']['version']             = "3.2.0.12"
 
 default['hops']['hdfs']['user']                = node['install']['user'].empty? ? "hdfs" : node['install']['user']


### PR DESCRIPTION
HOPSFS-139 Bump Hops Hadoop Version to 3.2.0.12